### PR TITLE
Fixes to policy management.

### DIFF
--- a/plugins/module_utils/policy_utils.py
+++ b/plugins/module_utils/policy_utils.py
@@ -280,6 +280,10 @@ def _check_list(remote_values, local_values):
     :param list local_values: The member values
     :rtype: bool
     """
+    if remote_values is None:
+        remote_values = []
+    if local_values is None:
+        local_values = []
     if len(remote_values) == len(local_values):
         return all(x in local_values for x in remote_values)
     else:

--- a/plugins/module_utils/policy_utils.py
+++ b/plugins/module_utils/policy_utils.py
@@ -299,6 +299,9 @@ def _check_value(remote_value, local_value):
     :return: True if both parameters hold the same value, False otherwise
     :rtype: bool
     """
+    if isinstance(remote_value, bool) or isinstance(local_value, bool):
+        remote_value = False if remote_value is None else remote_value
+        local_value = False if local_value is None else local_value
     if remote_value is not None and local_value is not None:
         return True if remote_value == local_value else False
     elif remote_value is None and local_value is None:

--- a/plugins/modules/venafi_policy.py
+++ b/plugins/modules/venafi_policy.py
@@ -155,14 +155,15 @@ class VPolicyManagement:
             if remote_ps:
                 # Policy already exists in Venafi platform
                 # Validate that both, the source policy and the Venafi platform policy have the same content
-                local_ps = self._read_policy_spec_file(self.local_ps)
-                changed, new_msgs = check_policy_specification(local_ps, remote_ps)
+                # local_ps = self._read_policy_spec_file(self.local_ps)
+                # changed, new_msgs = check_policy_specification(local_ps, remote_ps)
+                changed = True
                 if changed:
                     result[F_CHANGED] = True
                     result[F_POLICY_UPDATED] = self.zone
-                    msgs.extend(new_msgs)
-                    msgs.append('Changes detected in local file %s against remote policy %s.'
-                                % (self.local_ps, self.zone))
+                    # msgs.extend(new_msgs)
+                    msgs.append('Policy %s found on Venafi platform. Overriding with values from %s'
+                                % (self.zone, self.local_ps))
                 else:
                     msgs.append('No changes detected in local file %s. No action required' % self.local_ps)
             else:
@@ -284,7 +285,7 @@ def main():
         # TODO create delete_policy() method. Not yet available on vcert python library
         vcert.delete_policy()
 
-    vcert.validate()
+    # vcert.validate()
     module.exit_json(**check_result)
 
 

--- a/plugins/modules/venafi_policy.py
+++ b/plugins/modules/venafi_policy.py
@@ -88,7 +88,7 @@ except ImportError:
 
 HAS_VCERT = True
 try:
-    from vcert.errors import VenafiConnectionError
+    from vcert.errors import VenafiError
     from vcert.parser import json_parser, yaml_parser
     from vcert.policy import PolicySpecification
 except ImportError:
@@ -146,7 +146,7 @@ class VPolicyManagement:
         msgs = []
         try:
             remote_ps = self.connection.get_policy(self.zone)
-        except VenafiConnectionError as e:
+        except VenafiError as e:
             self.module.debug('Get policy %s failed. Assuming Policy does not exist. Error: %s'
                               % (self.zone, to_native(e)))
             remote_ps = None

--- a/tests/ssh_ca/test_ssh_ca.py
+++ b/tests/ssh_ca/test_ssh_ca.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Venafi, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from os import environ
+import unittest
+
+from plugins.modules.venafi_ssh_ca import VSSHCertAuthority
+
+TPP_TOKEN_URL = environ.get("TPP_TOKEN_URL")
+TPP_ACCESS_TOKEN = environ.get("TPP_ACCESS_TOKEN")
+TPP_TRUST_BUNDLE = environ.get("TPP_TRUST_BUNDLE")
+
+
+class TestSSHCertificate(unittest.TestCase):
+    def test_retrieve_ca_public_key_no_auth(self):
+        params = get_params()
+        module = FakeModule(params)
+        vcert = VSSHCertAuthority(module)
+        result = vcert.retrieve_ssh_config()
+        print("Retrieve CA public key finished with result: %s", result)
+
+    def test_retrieve_ca_public_key_auth(self):
+        params = get_params(use_credentials=True)
+        module = FakeModule(params)
+        vcert = VSSHCertAuthority(module)
+        result = vcert.retrieve_ssh_config()
+        print("Retrieve CA public key and principals finished with result: %s", result)
+
+
+def get_params(use_credentials=False):
+    params = {
+        'test_mode': False,
+        'url': TPP_TOKEN_URL,
+        'trust_bundle': TPP_TRUST_BUNDLE if TPP_TRUST_BUNDLE else None
+    }
+    if use_credentials:
+        params['access_token'] = TPP_ACCESS_TOKEN
+    return params


### PR DESCRIPTION
- Changed error capture in the try-catch block from VenafiConnectionError to VenafiError.
- Validated that list values from policy specification are always initialized to empty (required for validations between local and remote files).