### PR TITLE
Fix for empty SANs on certificate

### DIFF
--- a/docs/version_history.md
+++ b/docs/version_history.md
@@ -11,7 +11,7 @@ We welcome and appreciate all contributions. Got questions or want to discuss so
 ## Version History
 
 #### 0.8.0
- * Added support for service generated CSR on VaaS. 
+ * Added support for service generated CSR on VaaS
  * Fixed issue with SANs validation when no SAN has been provided
  * Fixed issue when an empty private key file was being created on invalid scenarios
 #### 0.7.5

--- a/plugins/modules/venafi_certificate.py
+++ b/plugins/modules/venafi_certificate.py
@@ -602,8 +602,12 @@ class VCertificate:
         alt_names = []
         if cert.extensions:
             ext = cert.extensions
-            if ext.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME):
+            try:
                 alt_names = ext.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME).value
+            except x509.extensions.ExtensionNotFound as enf:
+                # If the OID is not found, the x509 object raises an error we need to catch.
+                alt_names = []
+
         for e in alt_names:
             if isinstance(e, x509.general_name.DNSName):
                 dns.append(e.value)


### PR DESCRIPTION
- Added try-except block for SANS not present in certificate object. Allowing the validation to continue.