### PR TITLE
Fix misleading warnings

### DIFF
--- a/plugins/module_utils/common_utils.py
+++ b/plugins/module_utils/common_utils.py
@@ -87,7 +87,7 @@ def get_venafi_connection(module, platform=None):
     apikey = module.params[F_APIKEY]
     trust_bundle = module.params[F_TRUST_BUNDLE]
 
-    if user or password:
+    if user is not None or password is not None:
         module.warn("user/password authentication is deprecated. Use access token instead.")
 
     # Legacy Connection. Deprecated. Do not use

--- a/plugins/module_utils/common_utils.py
+++ b/plugins/module_utils/common_utils.py
@@ -87,7 +87,7 @@ def get_venafi_connection(module, platform=None):
     apikey = module.params[F_APIKEY]
     trust_bundle = module.params[F_TRUST_BUNDLE]
 
-    if user != '' or password != '':
+    if user or password:
         module.warn("user/password authentication is deprecated. Use access token instead.")
 
     # Legacy Connection. Deprecated. Do not use

--- a/plugins/modules/venafi_certificate.py
+++ b/plugins/modules/venafi_certificate.py
@@ -749,7 +749,7 @@ def main():
         before_expired_hours=dict(type='int', required=False, default=72),
         chain_option=dict(type='str', required=False, default='last'),
         chain_path=dict(type='path', required=False),
-        common_name=dict(aliases=['CN', 'commonName', 'common_name'], type='str', required=True),
+        common_name=dict(aliases=['CN', 'commonName'], type='str', required=True),
         csr_origin=dict(type='str', choices=[CSR_ORIGIN_LOCAL, CSR_ORIGIN_SERVICE, CSR_ORIGIN_PROVIDED],
                         default=CSR_ORIGIN_LOCAL),
         csr_path=dict(type='path', required=False),


### PR DESCRIPTION
This fixes 2 different warning that you receiving when calling the modules in this collection.

First is the warning that you receive when using user/password authentication instead of token-based authentication. In the case they you do not use user/password authentication by not specifying the parameters `user` and `password` you still receive a warning due to the check looking for only in the case that both `user` and `password` are empty strings. This PR fixes this by replacing those checks against empty strings for a check against `None`.

The second warning occurs if you use the parameter `common_name`. Since the parameter `common_name` has an alias that matches the name, you receive a warning from Ansible saying that you are using `common_name` and its alias `common_name`. This removes the duplicate alias to remove that warning.