### PR TITLE
Let certificate_common_name fall back to inventory_hostname

### DIFF
--- a/roles/certificate/defaults/main.yml
+++ b/roles/certificate/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 credentials_file: credentials.yml
-# Use Ansible host FQDN for certificate common name
-certificate_common_name: "{{ ansible_fqdn }}"
+# Use Ansible host FQDN for certificate common name or fall back to inventory_hostname if not available, such as `gather_facts: false`
+certificate_common_name: "{{ ansible_fqdn | default(inventory_hostname) }}"
 
 # Directory where to place certificates
 certificate_cert_dir: "/etc/ssl/{{ certificate_common_name }}"


### PR DESCRIPTION
If the Ansible playbook is not gathering facts, ansible_fqdn is not available. This can happen if `gather_facts: false` is specified, which is a valid use case for API interactions with remote hosts. Set a default value to inventory_hostname which is always available