### PR TITLE
fix: ignores .venv folder by PyCharm for TAR building

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -71,3 +71,4 @@ build_ignore:
   - 'docs/*'
   - 'molecule/*'
   - 'venv/*'
+  - '.venv/*'


### PR DESCRIPTION
ignores `.venv` default name folder for Python virtual environment created by PyCharm