### PR TITLE
Add guard check for null csr_path

### DIFF
--- a/plugins/modules/venafi_certificate.py
+++ b/plugins/modules/venafi_certificate.py
@@ -391,7 +391,7 @@ class VCertificate:
                     self.module.fail_json(msg="Failed to determine extension type: %s" % n)
 
         # If csr_path exists, it takes priority over any other value (csr_origin)
-        if os.path.exists(self.csr_path) and os.path.isfile(self.csr_path):
+        if self.csr_path is not None and os.path.exists(self.csr_path) and os.path.isfile(self.csr_path):
             self.csr_origin = CSR_ORIGIN_PROVIDED
 
     def check_dirs_existed(self):


### PR DESCRIPTION
This is a quick fix for #67: 

[`if os.path.exists(self.csr_path) and os.path.isfile(self.csr_path):`](https://github.com/Venafi/ansible-collection-venafi/blob/4150bd1b3cde913b189101e39a3a1300042f421a/plugins/modules/venafi_certificate.py#L394) fails when `self.csr_path` is `None` which is a valid condition. Here we simply first check to see if `self.csr_path` is truthy.

The real fix would be to adequately define the expected behavior in the argument spec with `required_if`. TBD.