### PR TITLE
security: CWE-73: Prevent FQDN fact injection in certificate roles — VC-53694

### DIFF
--- a/roles/certificate/defaults/main.yml
+++ b/roles/certificate/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 credentials_file: credentials.yml
 # Use Ansible host FQDN for certificate common name
-certificate_common_name: "{{ ansible_fqdn }}"
+certificate_common_name: "{{ inventory_hostname }}"
 
 # Directory where to place certificates
-certificate_cert_dir: "/etc/ssl/{{ certificate_common_name }}"
+certificate_cert_dir: "/etc/ssl/{{ certificate_common_name | basename }}"
 # Paths for certificate and keys
 certificate_cert_path: "{{ certificate_cert_dir }}/{{ certificate_common_name }}.pem"
 certificate_cert_path_pkcs12: "{{ certificate_cert_dir }}/{{ certificate_common_name }}.p12"

--- a/roles/ssh_ca/defaults/main.yml
+++ b/roles/ssh_ca/defaults/main.yml
@@ -2,9 +2,9 @@
 credentials_file: credentials.yml
 
 # Use Ansible host FQDN for Certificate Authority public key filename
-ssh_ca_public_key_filename: "{{ ansible_fqdn }}"
+ssh_ca_public_key_filename: "{{ inventory_hostname }}"
 # Directory where to place Certificate Authority public key
-ssh_ca_dir: "/etc/ssh/ca/{{ ssh_ca_public_key_filename }}"
+ssh_ca_dir: "/etc/ssh/ca/{{ ssh_ca_public_key_filename | basename }}"
 ssh_ca_public_key_path: "{{ ssh_ca_dir }}/{{ ssh_ca_public_key_filename }}.pub"
 
 # Where to execute venafi_ssh_ca module. If set to false, Certificate Authority public key

--- a/roles/ssh_certificate/defaults/main.yml
+++ b/roles/ssh_certificate/defaults/main.yml
@@ -2,9 +2,9 @@
 credentials_file: credentials.yml
 
 # Use Ansible host FQDN for certificate common name
-ssh_key_id: "{{ ansible_fqdn }}"
+ssh_key_id: "{{ inventory_hostname }}"
 # Directory where to place certificates
-ssh_cert_dir: "/etc/ssh/{{ ssh_key_id }}"
+ssh_cert_dir: "/etc/ssh/{{ ssh_key_id | basename }}"
 # Paths for certificate and keys
 ssh_cert_path: "{{ ssh_cert_dir }}/{{ ssh_key_id }}-cert.pub"
 ssh_public_key_path: "{{ ssh_cert_dir }}/{{ ssh_key_id }}.pub"


### PR DESCRIPTION
## Summary

This PR fixes CWE-73 (External Control of File Name or Path) in the certificate, ssh_certificate, and ssh_ca roles by replacing remotely-gathered `ansible_fqdn` facts with controller-authoritative `inventory_hostname` values and sanitizing path components with the `basename` filter.

## Finding

**CWE-73: External Control of File Name or Path** (CVSS 8.3)

The certificate role derives both the certificate common name and all controller-side filesystem paths from the `ansible_fqdn` fact without sanitization. A compromised inventory member can:
- Forge its FQDN to impersonate another host
- Trigger path traversal on the Ansible controller
- Obtain Venafi-issued certificates bound to victim hostnames
- Access cached private keys for other hosts

**Affected files:**
- `roles/certificate/defaults/main.yml:4` - uses `ansible_fqdn` for CN and paths
- `roles/ssh_certificate/defaults/main.yml:5` - same pattern for SSH certificates
- `roles/ssh_ca/defaults/main.yml:5` - same pattern for SSH CA keys

## Remediation

Changed all three role defaults to:
1. Use `inventory_hostname` instead of `ansible_fqdn` for identity values
2. Apply `| basename` filter to path components to prevent directory traversal

**Changes:**
- `roles/certificate/defaults/main.yml`: Changed `certificate_common_name` from `{{ ansible_fqdn }}` to `{{ inventory_hostname }}` and sanitized `certificate_cert_dir` path
- `roles/ssh_certificate/defaults/main.yml`: Changed `ssh_key_id` from `{{ ansible_fqdn }}` to `{{ inventory_hostname }}` and sanitized `ssh_cert_dir` path  
- `roles/ssh_ca/defaults/main.yml`: Changed `ssh_ca_public_key_filename` from `{{ ansible_fqdn }}` to `{{ inventory_hostname }}` and sanitized `ssh_ca_dir` path

## Verification

The remediation prevents the attack:
- Hostile hosts can no longer forge their FQDN to impersonate other inventory members
- The controller uses only `inventory_hostname` (defined in the inventory file, not gathered from remote hosts) for certificate CN and filesystem operations
- Path traversal is blocked by the `basename` filter on directory components
- Certificate requests and key management are now scoped to the actual inventory identity, not the remotely-reported hostname

---
*Auto-generated by Project Logos Pattern-C remediation (VC-53694)*