### PR TITLE
chore(deps): bump vcert to >=0.21.1 for VC-56449 TPP service-CSR fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version History
 
+##### 1.3.1
+* Bumped the `vcert` dependency to `vcert>=0.21.1` in `requirements.in` and regenerated the hash-pinned `requirements.txt` lockfile (`vcert==0.21.1`). `vcert` 0.21.1 fixes service-generated CSR (`csr_origin: service`) enrollment on CyberArk Certificate Manager, Self-Hosted (TPP): the requested key specification (key type and size, e.g. RSA 4096) is now sent on the enrollment request, so TPP no longer silently falls back to the policy-folder default key size. This resolves the `Private key file does not contain a valid private key` failure in the `venafi_certificate` module that occurred when `privatekey_size` did not match the policy default (surfaced after upgrading to TPP 25.1+/25.3). Delivered entirely through the updated `vcert` SDK — no collection code changes.
+
 ##### 1.3.0
 * Added the `venafi_certificate_revoke` module to revoke a certificate on CyberArk Certificate Manager, Self-Hosted (TPP), SaaS, and NGTS (Strata Cloud Manager). Self-Hosted (TPP) revokes by certificate DN (`certificate_dn`) or SHA-1 `thumbprint` and honors retire/`no_retire`; SaaS and NGTS revoke by SHA-1 `thumbprint` (the DN and the `ca-compromise` reason are not supported, and `no_retire` is ignored). The reason vocabulary matches the Go `vcert revoke` command (`none`, `key-compromise`, `ca-compromise`, `affiliation-changed`, `superseded`, `cessation-of-operation`). Revocation is imperative: the module always attempts to revoke and the inherited `state` option is accepted but ignored.
 * Bumped the `vcert` dependency to `vcert>=0.21.0` in `requirements.in` and regenerated the hash-pinned `requirements.txt` lockfile. SaaS and NGTS certificate revocation is only available in `vcert` 0.21.0; Self-Hosted (TPP) revocation also works on earlier releases.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: venafi
 name: machine_identity
 
 # The version of the collection. Must be compatible with semantic versioning.
-version: 1.3.0
+version: 1.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
-vcert>=0.21.0
+vcert>=0.21.1
 cryptography>=42.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -401,7 +401,7 @@ urllib3==2.6.3 \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
     --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
     # via requests
-vcert==0.21.0 \
-    --hash=sha256:57e7e6bc239b6035e9a9c3bad6f697fc8332c2328adac8014c9ca481e588ea26 \
-    --hash=sha256:6641bda6460ad0d563c2d915a539670e97566fe6bf7486ac932a0f03a8ba7cf7
+vcert==0.21.1 \
+    --hash=sha256:50f6a3a6673de7e9579531c8b9928cf64b1b2cccdd1d0539efbcefd656802b75 \
+    --hash=sha256:a3cd57649340c86c260fcd3013c96b5dac8248dd89bc9c8f4af8bb14d696744c
     # via -r requirements.in


### PR DESCRIPTION
vcert 0.21.1 sends the requested key spec (type/size) on service-generated CSR (csr_origin: service) enrollment to TPP, so TPP no longer silently falls back to the policy-folder default key size. Fixes the "Private key file does not contain a valid private key" failure in venafi_certificate when privatekey_size did not match the policy default (surfaced on TPP 25.1+/25.3).

- requirements.in:  vcert>=0.21.0 -> vcert>=0.21.1
- requirements.txt: regenerated hash-pinned lockfile (vcert==0.21.1)
- galaxy.yml:       1.3.0 -> 1.3.1
- CHANGELOG.md:     add 1.3.1 entry